### PR TITLE
`typesafe-i18n` improvements

### DIFF
--- a/src/i18n/ja/index.ts
+++ b/src/i18n/ja/index.ts
@@ -1,6 +1,6 @@
-import type { BaseTranslation } from 'typesafe-i18n';
+import type { Translation } from '../i18n-types';
 
-const ja: BaseTranslation = {
+const ja: Translation = {
 	STARTUP: 'app started (JA)',
 	TITLE: 'Subatomos - 大空スバルファンサイト',
 	HOME: {


### PR DESCRIPTION
I just saw you are using `typesafe-i18n` in your repo.
The type `BaseTranslation` should only be used for your base translation. All other translations should use the generated `Translation` type, to get better TypeScript support.